### PR TITLE
Implement custom message functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ export default Component.extend({
 
 ## Validator API
 
+All validators take a [custom message option](#custom-validation-messages)
+
 #### `presence`
 
 Validates presence/absence of a value.
@@ -93,6 +95,7 @@ Validates presence/absence of a value.
 {
   propertyName: validatePresence(true), // must be present
   propertyName: validatePresence(false) // must be blank
+  propertyName: validatePresence({ presence: true }) // alternative option syntax
 }
 ```
 
@@ -255,7 +258,21 @@ export default assign({}, UserValidations, AdultValidations);
 
 ## Custom validation messages
 
-This is not yet supported, but is very high on the roadmap.
+Each validator that is a part of this library can utilize a `message` property on the `options` object passed to the validator. That `message` property can either be a string or a function.
+
+If `message` is a string, you can put particular placeholders into it that will be automatically replaced. For example:
+
+```js
+{
+  propertyName: validatePresence({presence: true, message: '{description} should be present'})
+}
+```
+
+`{description}` is a hardcoded placeholder that will be replaced with a normalized version of the property name being validated. Any other placeholder will map to properties of the `options` object you pass to the validator.
+
+Message can also accept a function with the signature `(key, type, value, context)`. Key is the property name being validated. Type is the type of validation being performed (in the case of validators such as `number` or `length`, there can be a couple of different ones.) Value is the actual value being validated. Context maps to the `options` object you passed to the validator.
+
+If `message` is a function, it must return the error message as a string.
 
 ## Installation
 

--- a/addon/utils/validation-errors.js
+++ b/addon/utils/validation-errors.js
@@ -9,6 +9,8 @@ import messages from 'ember-changeset-validations/validators/messages';
 
 const {
   String: { dasherize, capitalize },
+  assert,
+  typeOf,
   isNone,
   get
 } = Ember;
@@ -27,7 +29,21 @@ export function formatMessage(message, context = {}) {
   return message.replace(regex, (s, attr) => context[attr]);
 }
 
-export default function buildMessage(key, type, context = {}) {
+export default function buildMessage(key, type, value, context = {}) {
   let description = formatDescription(key);
+
+  if (context.message) {
+    let message = context.message;
+
+    if (typeOf(message) === 'function') {
+      let builtMessage = message(key, type, value, context);
+      assert('Custom message function must return a string', typeOf(builtMessage) === 'string');
+
+      return builtMessage;
+    }
+
+    return formatMessage(message, assign({ description }, context));
+  }
+
   return formatMessage(get(messages, type), assign({ description }, context));
 }

--- a/addon/validators/confirmation.js
+++ b/addon/validators/confirmation.js
@@ -7,9 +7,11 @@ const {
   isEqual
 } = Ember;
 
-export default function validateConfirmation({ on }) {
+export default function validateConfirmation(options = {}) {
+  let { on } = options;
+
   return (key, newValue, _oldValue, changes) => {
     return isPresent(newValue) && isEqual(get(changes, on), newValue) ||
-      buildMessage(key, 'confirmation', { on });
+      buildMessage(key, 'confirmation', newValue, options);
   };
 }

--- a/addon/validators/exclusion.js
+++ b/addon/validators/exclusion.js
@@ -9,10 +9,12 @@ import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 
 const { typeOf } = Ember;
 
-export default function validateExclusion({ list, range }) {
+export default function validateExclusion(options = {}) {
+  let { list, range } = options;
+
   return (key, value) => {
     if (list && list.indexOf(value) !== -1) {
-      return buildMessage(key, 'exclusion');
+      return buildMessage(key, 'exclusion', value, options);
     }
 
     if (range && range.length === 2) {
@@ -20,7 +22,7 @@ export default function validateExclusion({ list, range }) {
       let equalType = typeOf(value) === typeOf(min) && typeOf(value) === typeOf(max);
 
       if (equalType && min <= value && value <= max) {
-        return buildMessage(key, 'exclusion');
+        return buildMessage(key, 'exclusion', value, options);
       }
     }
 

--- a/addon/validators/format.js
+++ b/addon/validators/format.js
@@ -15,7 +15,9 @@ const regularExpressions = {
   url: /(?:([A-Za-z]+):)?(\/{0,3})[a-zA-Z0-9][a-zA-Z-0-9]*(\.[\w-]+)+([\w.,@?^=%&amp;:\/~+#-{}]*[\w@?^=%&amp;\/~+#-{}])??/
 };
 
-export default function validateFormat({ allowBlank, type, regex } = {}) {
+export default function validateFormat(options = {}) {
+  let { allowBlank, type, regex } = options;
+
   return (key, value) => {
     if (allowBlank && isEmpty(value)) {
       return true;
@@ -27,9 +29,9 @@ export default function validateFormat({ allowBlank, type, regex } = {}) {
 
     if (regex && !regex.test(value)) {
       if (type) {
-        return buildMessage(key, type);
+        return buildMessage(key, type, value, options);
       }
-      return buildMessage(key, 'invalid');
+      return buildMessage(key, 'invalid', value, options);
     }
 
     return true;

--- a/addon/validators/inclusion.js
+++ b/addon/validators/inclusion.js
@@ -9,10 +9,12 @@ import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 
 const { typeOf } = Ember;
 
-export default function validateInclusion({ list, range }) {
+export default function validateInclusion(options = {}) {
+  let { list, range } = options;
+
   return (key, value) => {
     if (list && list.indexOf(value) === -1) {
-      return buildMessage(key, 'inclusion');
+      return buildMessage(key, 'inclusion', value, options);
     }
 
     if (range && range.length === 2) {
@@ -20,7 +22,7 @@ export default function validateInclusion({ list, range }) {
       let equalType = typeOf(value) === typeOf(min) && typeOf(value) === typeOf(max);
 
       if (!equalType || min > value || value > max) {
-        return buildMessage(key, 'inclusion');
+        return buildMessage(key, 'inclusion', value, options);
       }
     }
 

--- a/addon/validators/length.js
+++ b/addon/validators/length.js
@@ -15,7 +15,9 @@ const {
   typeOf
 } = Ember;
 
-export default function validateLength({ allowBlank, is, min, max } = {}) {
+export default function validateLength(options = {}) {
+  let { allowBlank, is, min, max } = options;
+
   return (key, value) => {
     let length = get(value, 'length');
 
@@ -24,23 +26,23 @@ export default function validateLength({ allowBlank, is, min, max } = {}) {
     }
 
     if (isNone(value)) {
-      return buildMessage(key, 'invalid', value);
+      return buildMessage(key, 'invalid', value, options);
     }
 
     if (isPresent(is) && typeOf(is) === 'number') {
-      return length === is || buildMessage(key, 'wrongLength', { is });
+      return length === is || buildMessage(key, 'wrongLength', value, options);
     }
 
     if (isPresent(min) && isPresent(max)) {
-      return (length >= min && length <= max) || buildMessage(key, 'between', { min, max });
+      return (length >= min && length <= max) || buildMessage(key, 'between', value, options);
     }
 
     if (isPresent(min) && isEmpty(max)) {
-      return length >= min || buildMessage(key, 'tooShort', { min });
+      return length >= min || buildMessage(key, 'tooShort', value, options);
     }
 
     if (isPresent(max) && isEmpty(min)) {
-      return length <= max || buildMessage(key, 'tooLong', { max });
+      return length <= max || buildMessage(key, 'tooLong', value, options);
     }
 
     return true;

--- a/addon/validators/number.js
+++ b/addon/validators/number.js
@@ -26,50 +26,50 @@ function _validateType(type, opts, numValue, key) {
   let expected = opts[type];
 
   if (type === 'is' && numValue !== expected) {
-    return buildMessage(key, 'equalTo', opts);
+    return buildMessage(key, 'equalTo', numValue, opts);
   } else if (type === 'lt' && numValue >= expected) {
-    return buildMessage(key, 'lessThan', opts);
+    return buildMessage(key, 'lessThan', numValue, opts);
   } else if (type === 'lte' && numValue > expected) {
-    return buildMessage(key, 'lessThanOrEqualTo', opts);
+    return buildMessage(key, 'lessThanOrEqualTo', numValue, opts);
   } else if (type === 'gt' && numValue <= expected) {
-    return buildMessage(key, 'greaterThan', opts);
+    return buildMessage(key, 'greaterThan', numValue, opts);
   } else if (type === 'gte' && numValue < expected) {
-    return buildMessage(key, 'greaterThanOrEqualTo', opts);
+    return buildMessage(key, 'greaterThanOrEqualTo', numValue, opts);
   } else if (type === 'positive' && numValue < 0) {
-    return buildMessage(key, 'positive', opts);
+    return buildMessage(key, 'positive', numValue, opts);
   } else if (type === 'odd' && numValue % 2 === 0) {
-    return buildMessage(key, 'odd', opts);
+    return buildMessage(key, 'odd', numValue, opts);
   } else if (type === 'even' && numValue % 2 !== 0) {
-    return buildMessage(key, 'even', opts);
+    return buildMessage(key, 'even', numValue, opts);
   }
 
   return true;
 }
 
-export default function validateNumber(opts = {}) {
+export default function validateNumber(options = {}) {
   return (key, value) => {
     let numValue = Number(value);
-    let optKeys = keys(opts);
+    let optKeys = keys(options);
 
-    if (opts.allowBlank && isEmpty(value)) {
+    if (options.allowBlank && isEmpty(value)) {
       return true;
     }
 
     if (typeof(value) === 'string' && isEmpty(value)) {
-      return buildMessage(key, 'notANumber');
+      return buildMessage(key, 'notANumber', value, options);
     }
 
     if(!_isNumber(numValue)) {
-      return buildMessage(key, 'notANumber', value);
+      return buildMessage(key, 'notANumber', value, options);
     }
 
-    if(isPresent(opts.integer) && !_isInteger(numValue)) {
-      return buildMessage(key, 'notAnInteger', value);
+    if(isPresent(options.integer) && !_isInteger(numValue)) {
+      return buildMessage(key, 'notAnInteger', value, options);
     }
 
     for (let i = 0; i < optKeys.length; i++) {
       let type = optKeys[i];
-      let m = _validateType(type, opts, numValue, key);
+      let m = _validateType(type, options, numValue, key);
 
       if (typeof m === 'string') {
         return m;

--- a/addon/validators/presence.js
+++ b/addon/validators/presence.js
@@ -21,12 +21,20 @@ function _isPresent(value) {
   return isPresent(value);
 }
 
+function _testPresence(key, value, presence, context = {}) {
+  if (presence) {
+    return _isPresent(value) || buildMessage(key, 'present', value, context);
+  } else {
+    return isBlank(value) || buildMessage(key, 'blank', value, context);
+  }
+}
+
 export default function validatePresence(opts) {
   return (key, value) => {
-    if (opts) {
-      return _isPresent(value) || buildMessage(key, 'present');
-    } else {
-      return isBlank(value) || buildMessage(key, 'blank');
+    if (typeof opts === 'boolean') {
+      return _testPresence(key, value, opts);
     }
+
+    return _testPresence(key, value, opts.presence, opts);
   };
 }

--- a/tests/unit/utils/validation-errors-test.js
+++ b/tests/unit/utils/validation-errors-test.js
@@ -21,3 +21,30 @@ test('#formatMessage formats a blank message', function(assert) {
 test('#buildMessage builds a validation message', function(assert) {
   assert.equal(buildMessage('firstName', 'invalid'), 'First name is invalid');
 });
+
+test('#buildMessage builds a custom message if custom message is string', function(assert) {
+  assert.equal(
+    buildMessage('firstName', 'custom', 'testValue', { message: "{description} can't be equal to {foo}", foo: 'foo' }),
+    "First name can't be equal to foo",
+    'Built message is generated correctly'
+  );
+});
+
+test('#buildMessage builds a custom message if custom message is a function', function(assert) {
+  assert.expect(5);
+
+  function message(key, type, value, context) {
+    assert.equal(key, 'firstName');
+    assert.equal(type, 'custom');
+    assert.equal(value, 'testValue');
+    assert.equal(context.foo, 'foo');
+
+    return 'some test message';
+  }
+
+  assert.equal(
+    buildMessage('firstName', 'custom', 'testValue', { message, foo: 'foo' }),
+    'some test message',
+    'correct custom error message is returned'
+  );
+});

--- a/tests/unit/validators/confirmation-test.js
+++ b/tests/unit/validators/confirmation-test.js
@@ -10,8 +10,46 @@ test('it accepts an `on` option', function(assert) {
   let opts = { on: 'password' };
   let validator = validateConfirmation(opts);
 
-  assert.equal(validator(key, undefined, undefined, changes), buildMessage(key, 'confirmation', opts));
-  assert.equal(validator(key, null, undefined, changes), buildMessage(key, 'confirmation', opts));
-  assert.equal(validator(key, '', undefined, changes), buildMessage(key, 'confirmation', opts));
+  assert.equal(validator(key, undefined, undefined, changes), buildMessage(key, 'confirmation', null, opts));
+  assert.equal(validator(key, null, undefined, changes), buildMessage(key, 'confirmation', null, opts));
+  assert.equal(validator(key, '', undefined, changes), buildMessage(key, 'confirmation', null, opts));
   assert.equal(validator(key, '1234567', undefined, changes), true);
+});
+
+test('it can output custom message string', function(assert) {
+  let changes = { password: '1234567' };
+  let key = 'passwordConfirmation';
+  let opts = { on: 'password', message: '{description} is not equal to {on}' };
+  let validator = validateConfirmation(opts);
+
+  assert.equal(
+    validator(key, undefined, undefined, changes),
+    'Password confirmation is not equal to password',
+    'custom message string is generated correctly'
+  );
+});
+
+test('it can output with custom message function', function(assert) {
+  assert.expect(5);
+
+  let changes = { password: '1234567' };
+  let key = 'passwordConfirmation';
+  let opts = {
+    on: 'password',
+    message: function (_key, type, value, context) {
+      assert.equal(_key, key);
+      assert.equal(type, 'confirmation');
+      assert.equal(value, 'testValue');
+      assert.equal(context.on, opts.on);
+
+      return 'some test message';
+    }
+  };
+  let validator = validateConfirmation(opts);
+
+  assert.equal(
+    validator(key, 'testValue', undefined, changes),
+    'some test message',
+    'custom message function is returned correctly'
+  );
 });

--- a/tests/unit/validators/exclusion-test.js
+++ b/tests/unit/validators/exclusion-test.js
@@ -2,7 +2,7 @@ import validateExclusion from 'dummy/validators/exclusion';
 import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 import { module, test } from 'qunit';
 
-module('Unit | Validator | length');
+module('Unit | Validator | exclusion');
 
 test('it accepts a `list` option', function(assert) {
   let key = 'title';
@@ -11,7 +11,7 @@ test('it accepts a `list` option', function(assert) {
 
   assert.equal(validator(key, ''), true);
   assert.equal(validator(key, 'Executive'), true);
-  assert.equal(validator(key, 'Manager'), buildMessage(key, 'exclusion', options));
+  assert.equal(validator(key, 'Manager'), buildMessage(key, 'exclusion', 'Manager', options));
 });
 
 test('it accepts a `range` option', function(assert) {
@@ -21,5 +21,32 @@ test('it accepts a `range` option', function(assert) {
 
   assert.equal(validator(key, ''), true);
   assert.equal(validator(key, 61), true);
-  assert.equal(validator(key, 21), buildMessage(key, 'exclusion', options));
+  assert.equal(validator(key, 21), buildMessage(key, 'exclusion', 21, options));
+});
+
+test('it can output custom message string', function(assert) {
+  let key = 'age';
+  let options = { range: [18, 60], message: 'Your {description} is invalid, should not be within {range}' };
+  let validator = validateExclusion(options);
+
+  assert.equal(validator(key, 20), 'Your Age is invalid, should not be within 18,60', 'custom message string generated correctly');
+});
+
+test('it can output custom message function', function(assert) {
+  assert.expect(4);
+
+  let key = 'age';
+  let options = {
+    list: ['Test'],
+    message: function(_key, type, value) {
+      assert.equal(_key, key);
+      assert.equal(type, 'exclusion');
+      assert.equal(value, 'Test');
+
+      return 'some test message';
+    }
+  };
+  let validator = validateExclusion(options);
+
+  assert.equal(validator(key, 'Test'), 'some test message', 'custom message function is returned correctly');
 });

--- a/tests/unit/validators/format-test.js
+++ b/tests/unit/validators/format-test.js
@@ -37,3 +37,31 @@ test('it accepts a `regex` option', function(assert) {
   assert.equal(validator(key, 'secretword'), true);
   assert.equal(validator(key, 'fail'), buildMessage(key, 'invalid'));
 });
+
+test('it can output custom message string', function(assert) {
+  let key = 'URL';
+  let options = { type: 'url', message: '{description} should be of type {type}' };
+  let validator = validateFormat(options);
+
+  assert.equal(validator(key, 'notaurl'), 'Url should be of type url', 'custom message string is generated correctly');
+});
+
+test('it can output custom message function', function(assert) {
+  assert.expect(5);
+
+  let key = 'URL';
+  let options = {
+    type: 'url',
+    message: function(key, type, value, context) {
+      assert.equal(key, 'URL');
+      assert.equal(type, 'url');
+      assert.equal(value, 'notaurl');
+      assert.equal(context.type, 'url');
+
+      return 'some test message';
+    }
+  };
+  let validator = validateFormat(options);
+
+  assert.equal(validator(key, 'notaurl'), 'some test message', 'custom message function is returned correctly');
+});

--- a/tests/unit/validators/inclusion-test.js
+++ b/tests/unit/validators/inclusion-test.js
@@ -2,15 +2,15 @@ import validateInclusion from 'dummy/validators/inclusion';
 import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 import { module, test } from 'qunit';
 
-module('Unit | Validator | length');
+module('Unit | Validator | inclusion');
 
 test('it accepts a `list` option', function(assert) {
   let key = 'title';
   let options = { list: ['Manager', 'VP', 'Director'] };
   let validator = validateInclusion(options);
 
-  assert.equal(validator(key, ''), buildMessage(key, 'inclusion', options));
-  assert.equal(validator(key, 'Executive'), buildMessage(key, 'inclusion', options));
+  assert.equal(validator(key, ''), buildMessage(key, 'inclusion', '', options));
+  assert.equal(validator(key, 'Executive'), buildMessage(key, 'inclusion', 'Executive', options));
   assert.equal(validator(key, 'Manager'), true);
 });
 
@@ -19,7 +19,34 @@ test('it accepts a `range` option', function(assert) {
   let options = { range: [18, 60] };
   let validator = validateInclusion(options);
 
-  assert.equal(validator(key, ''), buildMessage(key, 'inclusion', options));
-  assert.equal(validator(key, 61), buildMessage(key, 'inclusion', options));
+  assert.equal(validator(key, ''), buildMessage(key, 'inclusion', '', options));
+  assert.equal(validator(key, 61), buildMessage(key, 'inclusion', 61, options));
   assert.equal(validator(key, 21), true);
+});
+
+test('it can output custom message string', function(assert) {
+  let key = 'age';
+  let options = { range: [18, 60], message: 'Your {description} is invalid, should be within {range}' };
+  let validator = validateInclusion(options);
+
+  assert.equal(validator(key, 92), 'Your Age is invalid, should be within 18,60', 'custom message string is generated correctly');
+});
+
+test('it can output custom message function', function(assert) {
+  assert.expect(4);
+
+  let key = 'age';
+  let options = {
+    list: ['Something'],
+    message: function(_key, type, value) {
+      assert.equal(_key, key);
+      assert.equal(type, 'inclusion');
+      assert.equal(value, 'Test');
+
+      return 'some test message';
+    }
+  };
+  let validator = validateInclusion(options);
+
+  assert.equal(validator(key, 'Test'), 'some test message', 'custom message function is returned correctly');
 });

--- a/tests/unit/validators/length-test.js
+++ b/tests/unit/validators/length-test.js
@@ -9,7 +9,7 @@ test('it accepts a `min` option', function(assert) {
   let options = { min: 1 };
   let validator = validateLength(options);
 
-  assert.equal(validator(key, ''), buildMessage(key, 'tooShort', options));
+  assert.equal(validator(key, ''), buildMessage(key, 'tooShort', '', options));
   assert.equal(validator(key, 'a'), true);
 });
 
@@ -20,7 +20,7 @@ test('it accepts a `max` option', function(assert) {
 
   assert.equal(validator(key, ''), true);
   assert.equal(validator(key, 'a'), true);
-  assert.equal(validator(key, 'ab'), buildMessage(key, 'tooLong', options));
+  assert.equal(validator(key, 'ab'), buildMessage(key, 'tooLong', 'ab', options));
 });
 
 test('it accepts a `min` and `max` option', function(assert) {
@@ -28,11 +28,11 @@ test('it accepts a `min` and `max` option', function(assert) {
   let options = { min: 1, max: 3 };
   let validator = validateLength(options);
 
-  assert.equal(validator(key, ''), buildMessage(key, 'between', options));
+  assert.equal(validator(key, ''), buildMessage(key, 'between', '', options));
   assert.equal(validator(key, 'a'), true);
   assert.equal(validator(key, 'ab'), true);
   assert.equal(validator(key, 'abc'), true);
-  assert.equal(validator(key, 'abcd'), buildMessage(key, 'between', options));
+  assert.equal(validator(key, 'abcd'), buildMessage(key, 'between', '', options));
 });
 
 test('it accepts an `is` option', function(assert) {
@@ -40,9 +40,9 @@ test('it accepts an `is` option', function(assert) {
   let options = { is: 2 };
   let validator = validateLength(options);
 
-  assert.equal(validator(key, 'a'), buildMessage(key, 'wrongLength', options));
+  assert.equal(validator(key, 'a'), buildMessage(key, 'wrongLength', '', options));
   assert.equal(validator(key, 'ab'), true);
-  assert.equal(validator(key, 'abc'), buildMessage(key, 'wrongLength', options));
+  assert.equal(validator(key, 'abc'), buildMessage(key, 'wrongLength', '', options));
 });
 
 test('it accepts an `allowBlank` option', function(assert) {
@@ -52,4 +52,32 @@ test('it accepts an `allowBlank` option', function(assert) {
 
   assert.equal(validator(key, ''), true);
   assert.equal(validator(key, 'a'), true);
+});
+
+test('it can output custom message string', function(assert) {
+  let key = 'firstName';
+  let options = { is: 2, message: '{description} should be length {is}' };
+  let validator = validateLength(options);
+
+  assert.equal(validator(key, 'abc'), 'First name should be length 2', 'custom messsage string is generated correctly');
+});
+
+test('it can output custom message function', function(assert) {
+  assert.expect(5);
+
+  let key = 'firstName';
+  let options = {
+    is: 2,
+    message: function (_key, type, value, context) {
+      assert.equal(_key, key);
+      assert.equal(type, 'wrongLength');
+      assert.equal(value, 'abc');
+      assert.equal(context.is, 2);
+
+      return 'some test message';
+    }
+  };
+  let validator = validateLength(options);
+
+  assert.equal(validator(key, 'abc'), 'some test message', 'custom message function is returned correctly');
 });

--- a/tests/unit/validators/number-test.js
+++ b/tests/unit/validators/number-test.js
@@ -18,7 +18,7 @@ test('it rejects non-numbers', function(assert) {
   let options = {};
   let validator = validateNumber(options);
 
-  assert.equal(validator(key, 'not a number'), buildMessage(key, 'notANumber', options));
+  assert.equal(validator(key, 'not a number'), buildMessage(key, 'notANumber', 'not a number', options));
   assert.equal(validator(key, '7'), true);
 });
 
@@ -36,7 +36,7 @@ test('it accepts an `integer` option', function(assert) {
   let options = { integer: true };
   let validator = validateNumber(options);
 
-  assert.equal(validator(key, '8.5'), buildMessage(key, 'notAnInteger', options));
+  assert.equal(validator(key, '8.5'), buildMessage(key, 'notAnInteger', '8.5', options));
   assert.equal(validator(key, '7'), true);
 });
 
@@ -45,7 +45,7 @@ test('it accepts an `is` option', function(assert) {
   let options = { is: 12 };
   let validator = validateNumber(options);
 
-  assert.equal(validator(key, '8.5'), buildMessage(key, 'equalTo', options));
+  assert.equal(validator(key, '8.5'), buildMessage(key, 'equalTo', '8.5', options));
   assert.equal(validator(key, '12'), true);
 });
 
@@ -54,8 +54,8 @@ test('it accepts a `lt` option', function(assert) {
   let options = { lt: 12 };
   let validator = validateNumber(options);
 
-  assert.equal(validator(key, '15'), buildMessage(key, 'lessThan', options));
-  assert.equal(validator(key, '12'), buildMessage(key, 'lessThan', options));
+  assert.equal(validator(key, '15'), buildMessage(key, 'lessThan', '15', options));
+  assert.equal(validator(key, '12'), buildMessage(key, 'lessThan', '12', options));
   assert.equal(validator(key, '4'), true);
 });
 
@@ -64,7 +64,7 @@ test('it accepts a `lte` option', function(assert) {
   let options = { lte: 12 };
   let validator = validateNumber(options);
 
-  assert.equal(validator(key, '15'), buildMessage(key, 'lessThanOrEqualTo', options));
+  assert.equal(validator(key, '15'), buildMessage(key, 'lessThanOrEqualTo', '15', options));
   assert.equal(validator(key, '12'), true);
   assert.equal(validator(key, '4'), true);
 });
@@ -75,8 +75,8 @@ test('it accepts a `gt` option', function(assert) {
   let validator = validateNumber(options);
 
   assert.equal(validator(key, '15'), true);
-  assert.equal(validator(key, '12'), buildMessage(key, 'greaterThan', options));
-  assert.equal(validator(key, '4'), buildMessage(key, 'greaterThan', options));
+  assert.equal(validator(key, '12'), buildMessage(key, 'greaterThan', '12', options));
+  assert.equal(validator(key, '4'), buildMessage(key, 'greaterThan', '4', options));
 });
 
 test('it accepts a `gte` option', function(assert) {
@@ -86,7 +86,7 @@ test('it accepts a `gte` option', function(assert) {
 
   assert.equal(validator(key, '15'), true);
   assert.equal(validator(key, '12'), true);
-  assert.equal(validator(key, '4'), buildMessage(key, 'greaterThanOrEqualTo', options));
+  assert.equal(validator(key, '4'), buildMessage(key, 'greaterThanOrEqualTo', '4', options));
 });
 
 test('it accepts a `positive` option', function(assert) {
@@ -95,7 +95,7 @@ test('it accepts a `positive` option', function(assert) {
   let validator = validateNumber(options);
 
   assert.equal(validator(key, '15'), true);
-  assert.equal(validator(key, '-12'), buildMessage(key, 'positive', options));
+  assert.equal(validator(key, '-12'), buildMessage(key, 'positive', '-12', options));
 });
 
 test('it accepts an `odd` option', function(assert) {
@@ -104,7 +104,7 @@ test('it accepts an `odd` option', function(assert) {
   let validator = validateNumber(options);
 
   assert.equal(validator(key, '15'), true);
-  assert.equal(validator(key, '34'), buildMessage(key, 'odd', options));
+  assert.equal(validator(key, '34'), buildMessage(key, 'odd', '34', options));
 });
 
 test('it accepts an `even` option', function(assert) {
@@ -112,6 +112,34 @@ test('it accepts an `even` option', function(assert) {
   let options = { even: true };
   let validator = validateNumber(options);
 
-  assert.equal(validator(key, '15'), buildMessage(key, 'even', options));
+  assert.equal(validator(key, '15'), buildMessage(key, 'even', '15', options));
   assert.equal(validator(key, '34'), true);
+});
+
+test('it can output custom message string', function(assert) {
+  let key = 'age';
+  let options = { even: true, message: 'Even {description} is wrong' };
+  let validator = validateNumber(options);
+
+  assert.equal(validator(key, 33), 'Even Age is wrong', 'custom message string is generated correctly');
+});
+
+test('it can output custom message function', function(assert) {
+  assert.expect(5);
+
+  let key = 'age';
+  let options = {
+    even: true,
+    message: function(_key, type, value, context) {
+      assert.equal(_key, key);
+      assert.equal(type, 'even');
+      assert.equal(value, 33);
+      assert.strictEqual(context.even, true);
+
+      return 'some test message';
+    }
+  };
+  let validator = validateNumber(options);
+
+  assert.equal(validator(key, 33), 'some test message', 'custom message function is returned correctly');
 });

--- a/tests/unit/validators/presence-test.js
+++ b/tests/unit/validators/presence-test.js
@@ -23,3 +23,51 @@ test('it accepts a `false` option', function(assert) {
   assert.equal(validator(key, ''), true);
   assert.equal(validator(key, 'a'), buildMessage(key, 'blank'));
 });
+
+test('it accepts a true `presence` option', function(assert) {
+  let key = 'firstName';
+  let validator = validatePresence({ presence: true });
+
+  assert.equal(validator(key, undefined), buildMessage(key, 'present'));
+  assert.equal(validator(key, null), buildMessage(key, 'present'));
+  assert.equal(validator(key, ''), buildMessage(key, 'present'));
+  assert.equal(validator(key, 'a'), true);
+});
+
+test('it accepts a false `presence` option', function(assert) {
+  let key = 'firstName';
+  let validator = validatePresence({ presence: false });
+
+  assert.equal(validator(key, undefined), true);
+  assert.equal(validator(key, null), true);
+  assert.equal(validator(key, ''), true);
+  assert.equal(validator(key, 'a'), buildMessage(key, 'blank'));
+});
+
+test('it can output a custom message string', function(assert) {
+  let key = 'firstName';
+  let options = { presence: true, message: '{description} should be present' };
+  let validator = validatePresence(options);
+
+  assert.equal(validator(key, ''), 'First name should be present', 'custom message string is generated correctly');
+});
+
+test('it can output a custom message function', function(assert) {
+  assert.expect(5);
+
+  let key = 'firstName';
+  let options = {
+    presence: false,
+    message: function(_key, type, value, context) {
+      assert.equal(_key, key);
+      assert.equal(type, 'blank');
+      assert.equal(value, 'test');
+      assert.strictEqual(context.presence, false);
+
+      return 'some test message';
+    }
+  };
+  let validator = validatePresence(options);
+
+  assert.equal(validator(key, 'test'), 'some test message', 'custom message function is returned correctly');
+});


### PR DESCRIPTION
closes #24
- add optional `message` property to each validator's options object
- update buildMessage function to handle both string and function message values
- update tests to work with new method signature