### PR TITLE
Add `inverse` option to format validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Validates a `String` based on a regular expression.
   propertyName: validateFormat({ type: 'phone' }), // built-in phone format
   propertyName: validateFormat({ type: 'url' }), // built-in URL format
   propertyName: validateFormat({ regex: \w{6,30} }) // custom regular expression
+  propertyName: validateFormat({ type: 'email', inverse: true }) // passes if the value doesn't match the given format
 }
 ```
 

--- a/addon/validators/format.js
+++ b/addon/validators/format.js
@@ -7,7 +7,7 @@
 import Ember from 'ember';
 import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 
-const { isEmpty } = Ember;
+const { isEmpty, assert, typeOf } = Ember;
 
 const regularExpressions = {
   email: /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/,
@@ -16,7 +16,9 @@ const regularExpressions = {
 };
 
 export default function validateFormat(options = {}) {
-  let { allowBlank, type, regex } = options;
+  let { allowBlank, type, regex, inverse = false } = options;
+
+  assert('inverse options should be a boolean', typeOf(inverse) === 'boolean');
 
   return (key, value) => {
     if (allowBlank && isEmpty(value)) {
@@ -27,8 +29,8 @@ export default function validateFormat(options = {}) {
       regex = regularExpressions[type];
     }
 
-    if (regex && !regex.test(value)) {
-      if (type) {
+    if (regex && (regex.test(value) === inverse)) {
+      if (type && !inverse) {
         return buildMessage(key, type, value, options);
       }
       return buildMessage(key, 'invalid', value, options);

--- a/tests/unit/validators/format-test.js
+++ b/tests/unit/validators/format-test.js
@@ -38,6 +38,24 @@ test('it accepts a `regex` option', function(assert) {
   assert.equal(validator(key, 'fail'), buildMessage(key, 'invalid'));
 });
 
+test('it accepts an `inverse` option with defined regex', function(assert) {
+  let key = 'email';
+  let options = { type: 'email', inverse: true };
+  let validator = validateFormat(options);
+
+  assert.equal(validator(key, 'test@example.com'), buildMessage(key, 'invalid'), 'email fails format test');
+  assert.equal(validator(key, 'notanemail'), true, 'non-email passes format test');
+});
+
+test('it accepts an `inverse` option with custom regex', function(assert) {
+  let key = 'custom';
+  let options = { regex: /^customregex$/, inverse: true };
+  let validator = validateFormat(options);
+
+  assert.equal(validator(key, 'customregex'), buildMessage(key, 'invalid'), 'matching regex fails format test');
+  assert.equal(validator(key, 'notmatching'), true, 'non-matching regex passes format test');
+});
+
 test('it can output custom message string', function(assert) {
   let key = 'URL';
   let options = { type: 'url', message: '{description} should be of type {type}' };


### PR DESCRIPTION
no issue
- allows validation to fail when the regex matches instead of when it doesn't

@poteto I wasn't entirely sure what to call the option name. `inverse` sounded the best to me, but I'm open to suggestions if you have a better one.