### PR TITLE
validator blueprint

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@
 bower.json
 ember-cli-build.js
 testem.js
+node-tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,4 @@ install:
 
 script:
   - ember try $EMBER_TRY_SCENARIO test --skip-cleanup
+  - npm run nodetest

--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ Validates that a field has the same value as another.
 
 Adding your own validator is super simple – there are no Base classes to extend! **Validators are just functions**. All you need to do is to create a function with the correct signature.
 
+Create a new validator using the blueprint:
+
+```
+ember generate validator <name>
+```
+
 `ember-changeset-validations` expects a higher order function that returns the validator function. The validator (or inner function) accepts a `key`, `newValue`, `oldValue` and `changes`. The outer function accepts options for the validator.
 
 ### Synchronous validators

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/validator/files/app/validators/__name__.js
+++ b/blueprints/validator/files/app/validators/__name__.js
@@ -1,0 +1,5 @@
+export default function validate<%= classifiedModuleName %>(/* options = {} */) {
+  return (/* key, newValue, oldValue, changes */) => {
+    return true;
+  };
+}

--- a/blueprints/validator/files/tests/unit/validators/__name__-test.js
+++ b/blueprints/validator/files/tests/unit/validators/__name__-test.js
@@ -1,0 +1,8 @@
+import { module, test } from 'qunit';
+import validate<%= classifiedModuleName %> from '<%= dasherizedPackageName %>/validators/<%= dasherizedModuleName %>';
+
+module('Unit | Validator | <%= dasherizedModuleName %>');
+
+test('it exists', function(assert) {
+  assert.ok(validate<%= classifiedModuleName %>());
+});

--- a/blueprints/validator/index.js
+++ b/blueprints/validator/index.js
@@ -1,0 +1,4 @@
+/*jshint node:true*/
+module.exports = {
+  description: 'Generates a changeset validator'
+};

--- a/node-test/blueprints/validator-test.js
+++ b/node-test/blueprints/validator-test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+var expect = require('ember-cli-blueprint-test-helpers/chai').expect;
+
+describe('Acceptance: ember generate and destroy validator', function() {
+  setupTestHooks(this);
+
+  it('generates and destroys a validator', function() {
+    var args = ['validator', 'is-positive'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, (file) => {
+        expect(file('app/validators/is-positive.js'))
+          .to.contain('export default function validateIsPositive(/* options = {} */) {\n');
+        expect(file('tests/unit/validators/is-positive-test.js'))
+          .to.contain("import validateIsPositive from 'my-app/validators/is-positive';")
+          .to.contain("module('Unit | Validator | is-positive');")
+          .to.contain('assert.ok(validateIsPositive());');
+    }));
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "ember build",
     "start": "ember server",
     "test": "ember try:each",
-    "nodetest": "mocha node-tests --recursive"
+    "nodetest": "mocha node-test --recursive"
   },
   "repository": "https://github.com/DockYard/ember-changeset-validations",
   "bugs": "https://github.com/DockYard/ember-changeset-validations/issues",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:each"
+    "test": "ember try:each",
+    "nodetest": "mocha node-tests --recursive"
   },
   "repository": "https://github.com/DockYard/ember-changeset-validations",
   "bugs": "https://github.com/DockYard/ember-changeset-validations/issues",
@@ -24,6 +25,7 @@
     "ember-ajax": "2.4.1",
     "ember-cli": "2.6.3",
     "ember-cli-app-version": "^1.0.0",
+    "ember-cli-blueprint-test-helpers": "^0.13.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
@@ -37,7 +39,8 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.1",
+    "mocha": "^2.5.3"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Implements new validator blueprint.

Usage:

 ```
ember g validator <name>
```

Changes:

- Install [ember-cli-blueprint-test-helpers](https://github.com/ember-cli/ember-cli-blueprint-test-helpers)
- Add new validator blueprint
- Update docs
- Add nodetest to travis config

Closes #55 