### PR TITLE
Allow null/undefined values in length validator

### DIFF
--- a/addon/validators/length.js
+++ b/addon/validators/length.js
@@ -19,8 +19,6 @@ export default function validateLength(options = {}) {
   let { allowBlank, is, min, max } = options;
 
   return (key, value) => {
-    let length = get(value, 'length');
-
     if (allowBlank && isEmpty(value)) {
       return true;
     }
@@ -28,6 +26,8 @@ export default function validateLength(options = {}) {
     if (isNone(value)) {
       return buildMessage(key, 'invalid', value, options);
     }
+
+    let length = get(value, 'length');
 
     if (isPresent(is) && typeOf(is) === 'number') {
       return length === is || buildMessage(key, 'wrongLength', value, options);

--- a/tests/unit/validators/length-test.js
+++ b/tests/unit/validators/length-test.js
@@ -52,6 +52,8 @@ test('it accepts an `allowBlank` option', function(assert) {
 
   assert.equal(validator(key, ''), true);
   assert.equal(validator(key, 'a'), true);
+  assert.equal(validator(key, null), true);
+  assert.equal(validator(key, undefined), true);
 });
 
 test('it can output custom message string', function(assert) {


### PR DESCRIPTION
Most ED models have null values in the initial state (unless a default value is specified). This prevents validateLength (even when using `allowBlank: true`) from failing whenever a null/undefined value is passed in.

Added a test that fails without this change.