### PR TITLE
Update docs to cover creating the Changeset programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,32 @@ export default Component.extend({
 }}
 ```
 
+When creating the `Changeset` programmatically instead of using the `changeset` helper, you will have to apply the `lookupValidator` function to convert the POJO to a validator function as expected by `Changeset`:
+
+```js
+import Ember from 'ember';
+import EmployeeValidations from '../validations/employee';
+import lookupValidator from 'ember-changeset-validations';
+
+const { Component } = Ember;
+
+export default Component.extend({
+  init() {
+    this._super(...arguments);
+    let model = get(this, 'model');
+    this.changeset = new Changeset(model, lookupValidator(EmployeeValidations), EmployeeValidations);
+  }
+});
+```
+
+```hbs
+{{dummy-form
+    changeset=changeset
+    submit=(action "submit")
+    rollback=(action "rollback")
+}}
+```
+
 ## Validator API
 
 All validators take a [custom message option](#custom-validation-messages)


### PR DESCRIPTION
The ember-changeset docs cover the case of creating the `Changeset` programmatically instead of using the template helper. However this does not work when using ember-changeset-validations, as the `lookupValidator` function needs to be applied on the validation POJO. The overriden `changeset` helper does that for you, but when not using, no validations are applied. 

This has been reported to me on the `ember-bootstrap-changeset-validations` addon and could be fixed by applying the mentioned `lookupValidator`: https://github.com/kaliber5/ember-bootstrap-changeset-validations/issues/1

This PR adds the missing documentation for that special case.