### PR TITLE
Link to ember-changeset-validations screencast series

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ ember install ember-changeset-validations
 
 This will also install `ember-changeset`.
 
+Watch [a 6-part video series on ember-changeset and ember-changeset-validations](https://www.emberscreencasts.com/tags/editing-and-validating-forms-with-ember-changeset) presented by EmberScreencasts.
+
 ## Usage
 
 This addon updates the `changeset` helper by taking in a validation map as a 2nd argument (instead of a validator function). This means that you can very easily compose validations and decouple the validation from the underlying model.


### PR DESCRIPTION
Added a link to the ember-changeset series (which has 3 videos on ember-changeset-validations), using a similar format to the EmberMap link in the ember-composable-helpers documentation.