### PR TITLE
Add allowBlank option to inclusion, exclusion, and confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ Validates that a value is a member of some list or range.
 ```js
 {
   propertyName: validateInclusion({ list: ['Foo', 'Bar'] }), // must be "Foo" or "Bar"
-  propertyName: validateInclusion({ range: [18, 60] }) // must be between 18 and 60
+  propertyName: validateInclusion({ range: [18, 60] }), // must be between 18 and 60
+  propertyName: validateInclusion({ allowBlank: true }), // can be blank
 }
 ```
 
@@ -188,7 +189,8 @@ Validates that a value is a not member of some list or range.
 ```js
 {
   propertyName: validateExclusion({ list: ['Foo', 'Bar'] }), // cannot be "Foo" or "Bar"
-  propertyName: validateExclusion({ range: [18, 60] }) // must not be between 18 and 60
+  propertyName: validateExclusion({ range: [18, 60] }), // must not be between 18 and 60
+  propertyName: validateExclusion({ allowBlank: true }), // can be blank
 }
 ```
 
@@ -217,7 +219,8 @@ Validates that a field has the same value as another.
 
 ```js
 {
-  propertyName: validateConfirmation({ on: 'password' }) // must match 'password'
+  propertyName: validateConfirmation({ on: 'password' }), // must match 'password'
+  propertyName: validateConfirmation({ allowBlank: true }), // can be blank
 }
 ```
 

--- a/addon/validators/confirmation.js
+++ b/addon/validators/confirmation.js
@@ -4,13 +4,18 @@ import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 const {
   get,
   isPresent,
-  isEqual
+  isEqual,
+  isEmpty,
 } = Ember;
 
 export default function validateConfirmation(options = {}) {
-  let { on } = options;
+  let { on, allowBlank } = options;
 
   return (key, newValue, _oldValue, changes/*, _content*/) => {
+    if (allowBlank && isEmpty(newValue)) {
+      return true;
+    }
+
     return isPresent(newValue) && isEqual(get(changes, on), newValue) ||
       buildMessage(key, 'confirmation', newValue, options);
   };

--- a/addon/validators/exclusion.js
+++ b/addon/validators/exclusion.js
@@ -6,12 +6,16 @@
 import Ember from 'ember';
 import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 
-const { typeOf } = Ember;
+const { isEmpty, typeOf } = Ember;
 
 export default function validateExclusion(options = {}) {
-  let { list, range } = options;
+  let { list, range, allowBlank } = options;
 
   return (key, value) => {
+    if (allowBlank && isEmpty(value)) {
+      return true;
+    }
+
     if (list && list.indexOf(value) !== -1) {
       return buildMessage(key, 'exclusion', value, options);
     }

--- a/addon/validators/inclusion.js
+++ b/addon/validators/inclusion.js
@@ -6,12 +6,16 @@
 import Ember from 'ember';
 import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 
-const { typeOf } = Ember;
+const { isEmpty, typeOf } = Ember;
 
 export default function validateInclusion(options = {}) {
-  let { list, range } = options;
+  let { list, range, allowBlank } = options;
 
   return (key, value) => {
+    if (allowBlank && isEmpty(value)) {
+      return true;
+    }
+
     if (list && list.indexOf(value) === -1) {
       return buildMessage(key, 'inclusion', value, options);
     }

--- a/tests/unit/validators/confirmation-test.js
+++ b/tests/unit/validators/confirmation-test.js
@@ -53,3 +53,11 @@ test('it can output with custom message function', function(assert) {
     'custom message function is returned correctly'
   );
 });
+
+test('it accepts an `allowBlank` option', function(assert) {
+  let key = 'email';
+  let options = { allowBlank: true };
+  let validator = validateConfirmation(options);
+
+  assert.equal(validator(key, ''), true, 'Empty string is accepted');
+});

--- a/tests/unit/validators/exclusion-test.js
+++ b/tests/unit/validators/exclusion-test.js
@@ -50,3 +50,11 @@ test('it can output custom message function', function(assert) {
 
   assert.equal(validator(key, 'Test'), 'some test message', 'custom message function is returned correctly');
 });
+
+test('it accepts an `allowBlank` option', function(assert) {
+  let key = 'email';
+  let options = { allowBlank: true };
+  let validator = validateExclusion(options);
+
+  assert.equal(validator(key, ''), true, 'Empty string is accepted');
+});

--- a/tests/unit/validators/inclusion-test.js
+++ b/tests/unit/validators/inclusion-test.js
@@ -50,3 +50,11 @@ test('it can output custom message function', function(assert) {
 
   assert.equal(validator(key, 'Test'), 'some test message', 'custom message function is returned correctly');
 });
+
+test('it accepts an `allowBlank` option', function(assert) {
+  let key = 'email';
+  let options = { allowBlank: true };
+  let validator = validateInclusion(options);
+
+  assert.equal(validator(key, ''), true, 'Empty string is accepted');
+});


### PR DESCRIPTION
There may be cases where a field needs to be validated for
inclusion, exclusion, or confirmation only if it is
filled in.  Adding `allowBlank` makes it possible for
developers to opt-in to this behavior without breaking
functionality for existing apps.

<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->


<!-- Please describe here what this pull request changes -->
