### PR TITLE
validateNumber should reject null

### DIFF
--- a/addon/validators/number.js
+++ b/addon/validators/number.js
@@ -49,20 +49,19 @@ function _validateType(type, opts, numValue, key) {
 
 export default function validateNumber(options = {}) {
   return (key, value) => {
-    if (isEmpty(value)) {
-      return !!options.allowBlank || buildMessage(key, 'notANumber', value, options);
+    if (isEmpty(value) && options.allowBlank) {
+      return true;
     }
 
     let numValue = Number(value);
-    let optKeys = keys(options);
 
-    if(!_isNumber(numValue)) {
+    if (isEmpty(value) || !_isNumber(numValue)) {
       return buildMessage(key, 'notANumber', value, options);
-    }
-
-    if(isPresent(options.integer) && !_isInteger(numValue)) {
+    } else if (isPresent(options.integer) && !_isInteger(numValue)) {
       return buildMessage(key, 'notAnInteger', value, options);
     }
+
+    let optKeys = keys(options);
 
     for (let i = 0; i < optKeys.length; i++) {
       let type = optKeys[i];

--- a/addon/validators/number.js
+++ b/addon/validators/number.js
@@ -49,16 +49,12 @@ function _validateType(type, opts, numValue, key) {
 
 export default function validateNumber(options = {}) {
   return (key, value) => {
+    if (isEmpty(value)) {
+      return !!options.allowBlank || buildMessage(key, 'notANumber', value, options);
+    }
+
     let numValue = Number(value);
     let optKeys = keys(options);
-
-    if (options.allowBlank && isEmpty(value)) {
-      return true;
-    }
-
-    if (typeof(value) === 'string' && isEmpty(value)) {
-      return buildMessage(key, 'notANumber', value, options);
-    }
 
     if(!_isNumber(numValue)) {
       return buildMessage(key, 'notANumber', value, options);

--- a/tests/unit/validators/number-test.js
+++ b/tests/unit/validators/number-test.js
@@ -9,10 +9,15 @@ test('it accepts an `allowBlank` option', function(assert) {
   let options = { allowBlank: true };
   let validator = validateNumber(options);
 
-  assert.equal(validator(key, ''), true);
-  assert.equal(validator(key, null), true);
-  assert.equal(validator(key, undefined), true);
-  assert.equal(validator(key, '6'), true);
+  assert.equal(validator(key, ''), true, 'empty string is allowed');
+  assert.equal(validator(key, null), true, 'null is allowed');
+  assert.equal(validator(key, undefined), true, 'undefined is allowed');
+  assert.equal(validator(key, '6'), true, 'numeric string is allowed');
+
+  assert.equal(validator(key, 'not a number'), buildMessage(key, 'notANumber', 'not a number', options),
+    'non-numeric string is not allowed');
+  assert.equal(validator(key, NaN), buildMessage(key, 'notANumber', NaN, options),
+    'NaN is not allowed');
 });
 
 test('it rejects non-numbers', function(assert) {
@@ -22,6 +27,7 @@ test('it rejects non-numbers', function(assert) {
 
   assert.equal(validator(key, 'not a number'), buildMessage(key, 'notANumber', 'not a number', options));
   assert.equal(validator(key, '7'), true);
+  assert.equal(validator(key, 7), true);
 });
 
 test('it rejects empty strings', function(assert) {

--- a/tests/unit/validators/number-test.js
+++ b/tests/unit/validators/number-test.js
@@ -10,6 +10,8 @@ test('it accepts an `allowBlank` option', function(assert) {
   let validator = validateNumber(options);
 
   assert.equal(validator(key, ''), true);
+  assert.equal(validator(key, null), true);
+  assert.equal(validator(key, undefined), true);
   assert.equal(validator(key, '6'), true);
 });
 
@@ -29,6 +31,15 @@ test('it rejects empty strings', function(assert) {
 
   assert.equal(validator(key, ''), buildMessage(key, 'notANumber'));
   assert.equal(validator(key, '7'), true);
+});
+
+test('it rejects null and undefined', function(assert) {
+  let key = 'age';
+  let options = {};
+  let validator = validateNumber(options);
+
+  assert.equal(validator(key, null), buildMessage(key, 'notANumber'));
+  assert.equal(validator(key, undefined), buildMessage(key, 'notANumber'));
 });
 
 test('it accepts an `integer` option', function(assert) {


### PR DESCRIPTION
Closes https://github.com/DockYard/ember-changeset-validations/issues/117

- Checks all empty values, not just if `string` or if `allowBlank`is enabled
- Moved the `let` declarations below `isEmpty` check, because they aren't needed prior to it
- Removed the `typeof value === 'string'` check, because the case is caught without it