### PR TITLE
Fix #139. `presence` messages were backwards.

### DIFF
--- a/addon/utils/messages.js
+++ b/addon/utils/messages.js
@@ -9,6 +9,10 @@ const assign = Ember.assign || Ember.merge;
 const Messages = assign({}, _Messages);
 
 export default assign(Messages, {
+  // Blank and present are flipped in ember-validators. Need to flip them back here
+  blank: _Messages.present,
+  present: _Messages.blank,
+
   getDescriptionFor(key = '') {
     return capitalize(dasherize(key).split(/[_-]/g).join(' '));
   }

--- a/addon/validators/presence.js
+++ b/addon/validators/presence.js
@@ -12,7 +12,6 @@ export default function validatePresence(options) {
     if (typeof result === 'boolean' || typeof result === 'string') {
       return result;
     } else {
-
       // We flipped the meaning behind `present` and `blank` so switch the two
       if (result.type === 'present') {
         result.type = 'blank';

--- a/tests/unit/utils/validation-errors-test.js
+++ b/tests/unit/utils/validation-errors-test.js
@@ -29,6 +29,16 @@ test('#buildMessage builds a custom message if custom message is string', functi
   );
 });
 
+test('#buildMessage returns correct defaults for "blank" and "present"', function(assert) {
+  assert.expect(2);
+  assert.equal(buildMessage('firstName', { type: 'present' }),
+    'First name can\'t be blank',
+    '"present" message is correct');
+  assert.equal(buildMessage('firstName', { type: 'blank' }),
+    'First name must be blank',
+    '"blank" message is correct');
+});
+
 test('#buildMessage builds a custom message if custom message is a function', function(assert) {
   assert.expect(5);
 


### PR DESCRIPTION
`buildMessage('present')` was returning `{key} must be blank` instead
of `{key} can't be blank`.

`buildMessage('blank')` was returning `{key} can't be blank` instead
of `{key} must be blank`.

<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->
Closes #139


