### PR TITLE
loosen ember-validators versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-changeset": "1.2.3",
     "ember-cli-babel": "^6.0.0",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-validators": "1.0.0"
+    "ember-validators": "^1.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
there's a downstream change that our app depends on. it shouldn't impact any upstream compatibility: offirgolan/ember-require-module/4
